### PR TITLE
Fix null check in BarcodeScannerExample

### DIFF
--- a/versions/unversioned/sdk/bar-code-scanner.rst
+++ b/versions/unversioned/sdk/bar-code-scanner.rst
@@ -71,7 +71,7 @@ Example
 
     render() {
       const { hasCameraPermission } = this.state;
-      if (typeof hasCameraPermission === 'null') {
+      if (hasCameraPermission === null) {
         return <View />;
       } else if (hasCameraPermission === false) {
         return <Text>No access to camera</Text>;


### PR DESCRIPTION
Because `typeof null` equals `"object"`, check if the variable equals `null` instead.