### PR TITLE
Add more details on developer menu

### DIFF
--- a/versions/unversioned/guides/debugging.rst
+++ b/versions/unversioned/guides/debugging.rst
@@ -28,6 +28,28 @@ we have found it to be more feature complete, faster and easier to use.
 `Download Genymotion <https://www.genymotion.com/fun-zone/>`_ (free version) and follow the `Genymotion installation guide <https://docs.genymotion.com/Content/01_Get_Started/Installation.htm>`_. Once you've installed Genymotion, create a virtual device - we recommend a Nexus 5, the Android version is up to you. Start up the virtual device when it's ready.
 If you run into any issues follow our :ref:`Genymotion guide <genymotion>`.
 
+Developer Menu
+==============
+
+This menu gives you access to several functions which are useful for debugging.
+It is also known as the Debug Menu.
+Invoking it depends on the device where you are running your application.
+
+On an iOS Device
+^^^^^^^^^^^^^^^^
+
+Shake the device a little bit.
+
+On Mac's iOS simulator
+^^^^^^^^^^^^^^^^^^^^^^
+
+Hit `Ctrl-Cmd-Z` on a Mac in the emulator to simulate the shake gesture.
+
+On Genymotion
+^^^^^^^^^^^^^
+
+Either press "Menu" button in Genymotion's toolbar, or just hit `Cmd-m`.
+
 Debugging Javascript
 ====================
 
@@ -48,8 +70,8 @@ execute code, etc, as you would when debugging a web app.
   as your development machine. This may not work on some public networks.
   ``localhost`` will not work for iOS unless you are in the simulator, and it
   only work on Android if your device is connected to your machine via usb.
-- Open the app on your device, then shake the device a little bit (or hit `Ctrl-Cmd-Z` on a Mac in the emulator) to reveal the
-  developer menu. Tap on ``Debug JS Remotely``. This should open up a Chrome
+- Open the app on your device, reveal the  developer menu,
+  then tap on ``Debug JS Remotely``. This should open up a Chrome
   tab with the URL ``http://localhost:19001/debugger-ui``. From there, you can
   set breakpoints and interact through the JavaScript console. Shake the
   device and stop Chrome debugging when you're done.
@@ -100,7 +122,7 @@ Hot Reloading and Live Reloading
 ================================
 `Hot Module Reloading <http://facebook.github.io/react-native/blog/2016/03/24/introducing-hot-reloading.html>`_
 is a quick way to reload changes without losing your state in the screen or
-navigation stack. To enable, just shake your device (or hit `Ctrl-Cmd-Z` on a Mac in the emulator) and tap the "Enable Hot
+navigation stack. To enable, invoke the developer menu and tap the "Enable Hot
 Reloading" item. Whereas Live Reload will reload the entire JS context, Hot
 Module Reloading will make your debug cycles even faster. However, make sure
 you don't have both options turned on, as that is unsupported behavior.


### PR DESCRIPTION
It took me about an hour to find out how to invoke the developer menu in Genymotion, similar to `Ctrl-Cmd-Z` in the emulator on Mac. It may be obvious for those familiar with Genymotion, but I had to find  this article http://www.differential.com/insights/intro-to-debugging-react-native-ios-and-android/ and learn that in Genymotion that you can simply press a button or use `Ctrl-m` keyboard shortcut.

To avoid repetition throughout the docs on how to access this menu, I created a separate section for this.