### PR TITLE
Minor Fixes in Firebase and Standalone App pages

### DIFF
--- a/versions/v13.0.0/guides/building-standalone-apps.rst
+++ b/versions/v13.0.0/guides/building-standalone-apps.rst
@@ -36,16 +36,16 @@ add any that are missing.
   .. code-block:: javascript
 
       {
-        name: "Playground",
-        icon: "https://s3.amazonaws.com/exp-us-standard/rnplay/app-icon.png",
-        version: "2.0.0",
-        slug: "rnplay",
-        sdkVersion: "8.0.0",
-        ios: {
-          bundleIdentifier: "org.rnplay.exp",
+        "name": "Playground",
+        "icon": "https://s3.amazonaws.com/exp-us-standard/rnplay/app-icon.png",
+        "version": "2.0.0",
+        "slug": "rnplay",
+        "sdkVersion": "8.0.0",
+        "ios": {
+          "bundleIdentifier": "org.rnplay.exp",
         },
-        android: {
-          package: "org.rnplay.exp",
+        "android": {
+          "package": "org.rnplay.exp",
         }
       }
 
@@ -53,7 +53,7 @@ add any that are missing.
   notation, but don't have to be related to a domain. In this case I chose
   ``org.rnplay.exp`` because the app's website is rnplay.org and this is the
   Exponent version of the app. Yours might be ``com.yourcompany.appname``.
-  
+
   You're probably not surprised that ``name``, ``iconUrl`` and ``version`` are
   required, but if you haven't used Exponent much you might be confused by
   ``slug`` and ``sdkVersion``. ``slug`` is the url name that your app's
@@ -65,7 +65,7 @@ add any that are missing.
 There are other options you might want to add to ``exp.json``. We have only
 covered what is required. See :ref:`Configuration with exp.json <exp>` for
 the full spec.
-  
+
 3. Start the build
 """"""""""""""""""
 

--- a/versions/v13.0.0/guides/using-firebase.rst
+++ b/versions/v13.0.0/guides/using-firebase.rst
@@ -75,7 +75,7 @@ rules for your data, including unauthenticated.
 2. Storing Data and Receiving Updates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Storing data through Firebase can be pretty simple. Image we're creating a game where
+Storing data through Firebase can be pretty simple. Imagine we're creating a game where
 highscores are stored in Firebase for everyone to see. We could create a users bucket in our data that is
 referenced by each user. Setting their highscore would be straightforward.
 


### PR DESCRIPTION
- A Typo in using-firebase.rst
- Qoutes for `exp.json` example in building-standalone-apps.rst . Previously it was not a valid JSON file.